### PR TITLE
Limit phpunit to version 4.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,6 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "4.8.*"
     }
 }


### PR DESCRIPTION
We can't afford using the latest version of phpunit if we want php 5.3.* compatibility