### PR TITLE
Use specific license tag (passes `composer validate`)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "include-path": [
         "./"
     ],
-    "license": "LGPL",
+    "license": "LGPL-2.1-or-later",
     "minimum-stability": "dev",
     "prefer-stable": true,
     "name": "pear/spreadsheet_excel_writer",


### PR DESCRIPTION
There's this license announcement:
https://pear.php.net/group/docs/20040402-la.php

It links to the LGPL Version 3, but in 2004 there was only 2.1. So it seems like that actual license definition must be LGPL-2.1 or later.