### PR TITLE
Fix overzealous cleanup of temporary files.

### DIFF
--- a/Spreadsheet/Excel/Writer/Workbook.php
+++ b/Spreadsheet/Excel/Writer/Workbook.php
@@ -604,7 +604,7 @@ class Spreadsheet_Excel_Writer_Workbook extends Spreadsheet_Excel_Writer_BIFFwri
 
         $total_worksheets = count($this->_worksheets);
         for ($i = 0; $i < $total_worksheets; $i++) {
-            while ($tmp = $this->_worksheets[$i]->getData()) {
+            while ($tmp = $this->_worksheets[$i]->getData(true)) {
                 $OLE->append($tmp);
             }
         }


### PR DESCRIPTION
By cleaning up the temporary files on close() we can no longer
call getData() which breaks pretty much everything except when
not using temporary files at all.

This was introduced in 6f5b44cd6b8