### PR TITLE
String concat performance improve

### DIFF
--- a/Spreadsheet/Excel/Writer/BIFFwriter.php
+++ b/Spreadsheet/Excel/Writer/BIFFwriter.php
@@ -163,7 +163,7 @@ class Spreadsheet_Excel_Writer_BIFFwriter extends PEAR
         if (strlen($data) > $this->_limit) {
             $data = $this->_addContinue($data);
         }
-        $this->_data      = $this->_data.$data;
+        $this->_data .= $data;
         $this->_datasize += strlen($data);
     }
 


### PR DESCRIPTION
Based on issue:  
https://pear.php.net/bugs/bug.php?id=18866  

Fix performance string concat  

```
php 7.4, write xls by 5 cell in each row

rows :: seconds

[now]
10000 :: 0.4
20000 :: 1.1
30000 :: 2.1
40000 :: 9.9
50000 :: 25.0
65534 :: 46.6

[after fix]
10000 :: 0.2
20000 :: 0.4
30000 :: 0.6
40000 :: 0.8
50000 :: 1.0
65534 :: 1.4
```