### PR TITLE
Update info URL in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pear/spreadsheet_excel_writer",
     "type": "library",
-    "description": "More info available on: https://github.com/pear/Spreadsheet_Excel_Writer",
+    "description": "Allows writing of Excel spreadsheets without the need for COM objects. Supports formulas, images (BMP) and all kinds of formatting for text and cells.",
     "license": "LGPL-2.1-or-later",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pear/spreadsheet_excel_writer",
     "type": "library",
-    "description": "More info available on: http://pear.php.net/package/Spreadsheet_Excel_Writer",
+    "description": "More info available on: https://github.com/pear/Spreadsheet_Excel_Writer",
     "license": "LGPL-2.1-or-later",
     "authors": [
         {


### PR DESCRIPTION
The composer package description is displayed when running `composer outdated`. The current URL refers to the old PEAR package page, which doesn't contain any information about the latest release.